### PR TITLE
Use -mod=readonly for golint.

### DIFF
--- a/test-runner/golint.sh
+++ b/test-runner/golint.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Get golint
-go get -u golang.org/x/lint/golint
+go get -mod=readonly golang.org/x/lint/golint
 
 # Set to "" if lint errors should not fail the job (default golint behaviour)
 # "-set_exit_status" otherwise


### PR DESCRIPTION
In OpenShift CI $go get: disabled by -mod=vendor

Use of -mod=readonly is a work-around for the issue.