### PR TITLE
Fix golint logic to be go version aware

### DIFF
--- a/test-runner/golint.sh
+++ b/test-runner/golint.sh
@@ -2,7 +2,12 @@
 set -ex
 
 # Get golint
-go get -mod=readonly golang.org/x/lint/golint
+GO_VERSION=`go version | { read _ _ ver _; echo ${ver#go}; }`
+if [ $(echo $GO_VERSION|awk -F. '{print $2}') -lt 14 ]; then
+  go get -mod=readonly golang.org/x/lint/golint
+else
+  go get -u golang.org/x/lint/golint
+fi
 
 # Set to "" if lint errors should not fail the job (default golint behaviour)
 # "-set_exit_status" otherwise


### PR DESCRIPTION
Flag -mod=readonly is deprecated in go 1.14,
ensure it's used only on previous versions.