### PR TITLE
Remove vendor folder from the golint command

### DIFF
--- a/test-runner/golint.sh
+++ b/test-runner/golint.sh
@@ -16,4 +16,6 @@ LINT_EXIT_STATUS="-set_exit_status"
 BASE_DIR="$(dirname $0)"
 cd "${BASE_DIR}/../.."
 
+[ -d "vendor" ] && rm -rf vendor
+
 golint ${LINT_EXIT_STATUS} ./...


### PR DESCRIPTION
vendor should be skipped using golint, however this tool
does not allow to skip it, removing as it's just vendor
with deps.