### PR TITLE
Add cache folder variable for golangci

### DIFF
--- a/test-runner/golangci.sh
+++ b/test-runner/golangci.sh
@@ -9,4 +9,4 @@ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/insta
 
 go mod vendor
 
-./bin/golangci-lint run -v
+GOLANGCI_LINT_CACHE=/tmp/golangci-cache ./bin/golangci-lint run -v


### PR DESCRIPTION
golangci in OpenShift prow environment is trying to
create /.cache folder and that's not permitted due
to different user running the job.

Setting GOLANGCI_LINT_CACHE resolves the issue.