### PR TITLE
Increase golangci-lint timeout to 2m from 1m

### DIFF
--- a/test-runner/golangci.sh
+++ b/test-runner/golangci.sh
@@ -9,4 +9,4 @@ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/insta
 
 go mod vendor
 
-GOLANGCI_LINT_CACHE=/tmp/golangci-cache ./bin/golangci-lint run -v
+GOLANGCI_LINT_CACHE=/tmp/golangci-cache ./bin/golangci-lint run --timeout=2m -v


### PR DESCRIPTION
golangci-lint is timing out occasionally, increasing
timeout from default 1m to 2m.