### PR TITLE
Revert "Use 'go list' to exclude vendor from vet"

### DIFF
--- a/test-runner/govet.sh
+++ b/test-runner/govet.sh
@@ -6,4 +6,4 @@ cd "${BASE_DIR}/../.."
 
 go mod vendor
 
-go list ./... | grep -v vendor | xargs go vet
+go vet ./...


### PR DESCRIPTION
This reverts commit 6115499c33054be1ce4ac6dc5e64174b0ee31441.