### PR TITLE
Use 'go install' to install golint

### DIFF
--- a/test-runner/golint.sh
+++ b/test-runner/golint.sh
@@ -2,12 +2,7 @@
 set -ex
 
 # Get golint
-GO_VERSION=`go version | { read _ _ ver _; echo ${ver#go}; }`
-if [ $(echo $GO_VERSION|awk -F. '{print $2}') -lt 14 ]; then
-  go get -mod=readonly golang.org/x/lint/golint
-else
-  go get -u golang.org/x/lint/golint
-fi
+go install golang.org/x/lint/golint
 
 # Set to "" if lint errors should not fail the job (default golint behaviour)
 # "-set_exit_status" otherwise


### PR DESCRIPTION
In go 1.17 'go get' was deprecated for installing executables. In
go 1.18 it is now required to use 'go install'.

This fixes the installation to use go install across the board
as all of our operators are now using go 1.17 or later.