### PR TITLE
Add .github workflows. Remove vendoring from test-runners

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,27 @@
+name: Golang lint, vet and unit test pipeline
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: github (govet, golint and gotest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.0 # don't bump this until all operators use 1.18
+      - name: Checkout project code
+        uses: actions/checkout@v2
+        with:
+          repository: openstack-k8s-operators/osp-director-operator
+      - name: Checkout openstack-k8s-operators-ci project
+        uses: actions/checkout@v2
+        with:
+          path: ./openstack-k8s-operators-ci
+      - name: Run govet.sh
+        run: ./openstack-k8s-operators-ci/test-runner/govet.sh
+      - name: Run golint.sh
+        run: ./openstack-k8s-operators-ci/test-runner/golint.sh
+      - name: Run gotest.sh
+        run: ./openstack-k8s-operators-ci/test-runner/gotest.sh

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -3,8 +3,8 @@ name: Golang lint, vet and unit test pipeline
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: github (govet, golint and gotest)
+  testmaster:
+    name: github (govet, golint and gotest) OSPdO master
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -15,6 +15,31 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: openstack-k8s-operators/osp-director-operator
+      - name: Checkout openstack-k8s-operators-ci project
+        uses: actions/checkout@v2
+        with:
+          path: ./openstack-k8s-operators-ci
+      - name: Run govet.sh
+        run: ./openstack-k8s-operators-ci/test-runner/govet.sh
+      - name: Run golint.sh
+        run: ./openstack-k8s-operators-ci/test-runner/golint.sh
+      - name: Run gotest.sh
+        run: ./openstack-k8s-operators-ci/test-runner/gotest.sh
+
+
+  teststable: # OSPdO v1.2.x
+    name: github (govet, golint and gotest) OSPdO v1.2.x
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.0 # don't bump this until we drop OSPdO v1.2.x
+      - name: Checkout project code
+        uses: actions/checkout@v2
+        with:
+          repository: openstack-k8s-operators/osp-director-operator
+          ref: v1.2.x
       - name: Checkout openstack-k8s-operators-ci project
         uses: actions/checkout@v2
         with:

--- a/test-runner/golint.sh
+++ b/test-runner/golint.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 set -ex
 
-# Get golint
-GO_VERSION=`go version | { read _ _ ver _; echo ${ver#go}; }`
-if [ $(echo $GO_VERSION|awk -F. '{print $2}') -lt 14 ]; then
-  go get -mod=readonly golang.org/x/lint/golint
-else
-  go get -u golang.org/x/lint/golint
-fi
-
 # Set to "" if lint errors should not fail the job (default golint behaviour)
 # "-set_exit_status" otherwise
 LINT_EXIT_STATUS="-set_exit_status"
@@ -16,6 +8,8 @@ LINT_EXIT_STATUS="-set_exit_status"
 BASE_DIR="$(dirname $0)"
 cd "${BASE_DIR}/../.."
 
-[ -d "vendor" ] && rm -rf vendor
+go version
+go get -u golang.org/x/lint/golint
+go install golang.org/x/lint/golint
 
 golint ${LINT_EXIT_STATUS} ./...

--- a/test-runner/gotest.sh
+++ b/test-runner/gotest.sh
@@ -4,6 +4,4 @@ set -ex
 BASE_DIR="$(dirname $0)"
 cd "${BASE_DIR}/../.."
 
-go mod vendor
-
 go test -v ./...

--- a/test-runner/govet.sh
+++ b/test-runner/govet.sh
@@ -4,6 +4,4 @@ set -ex
 BASE_DIR="$(dirname $0)"
 cd "${BASE_DIR}/../.."
 
-go mod vendor
-
 go vet ./...


### PR DESCRIPTION
Added a .github/workflow to test against OSP Director Operator. This should prevent us committing broken stuff here.

This also updates most of the test runners to remove vendoring which caused failures with golang 1.18.