### PR TITLE
Allow passing timeout to golangci.sh runner script

### DIFF
--- a/test-runner/golangci.sh
+++ b/test-runner/golangci.sh
@@ -9,10 +9,15 @@ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/insta
 
 MODULE_DIR="."
 if [ -n "$1" ]; then
-   MODULE_DIR=$1
+  MODULE_DIR=$1
+fi
+
+TIMEOUT=5
+if [ -n "$2" ] && [ "$2" -ge 1 ]; then
+  TIMEOUT=$2
 fi
 
 pushd ${MODULE_DIR}
 go mod vendor
-GOGC=10 GOLANGCI_LINT_CACHE=/tmp/golangci-cache ${BASE_DIR}/../../bin/golangci-lint run --timeout=2m -v
+GOGC=10 GOLANGCI_LINT_CACHE=/tmp/golangci-cache ${BASE_DIR}/../../bin/golangci-lint run --timeout=${TIMEOUT}m -v
 popd


### PR DESCRIPTION
Default timeout of 2m can be to low depending on the repo size.
Lets set the default to 5m and allow passing custom timeout via
param $2.