### PR TITLE
test runner updates for 1.17 (OSPdO)

### DIFF
--- a/test-runner/golangci.sh
+++ b/test-runner/golangci.sh
@@ -4,6 +4,8 @@ set -ex
 BASE_DIR="$(dirname $0)"
 cd "${BASE_DIR}/../.."
 
+export GOFLAGS="-mod=mod"
+
 # Install golangci
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -x -s --
 
@@ -18,6 +20,6 @@ if [ -n "$2" ] && [ "$2" -ge 1 ]; then
 fi
 
 pushd ${MODULE_DIR}
-go mod vendor
+
 GOGC=10 GOLANGCI_LINT_CACHE=/tmp/golangci-cache ${BASE_DIR}/../../bin/golangci-lint run --timeout=${TIMEOUT}m -v
 popd

--- a/test-runner/golint.sh
+++ b/test-runner/golint.sh
@@ -14,8 +14,11 @@ if [ -n "$1" ]; then
 fi
 
 pushd ${MODULE_DIR}
-go version
-go get -u golang.org/x/lint/golint
+
+export GOFLAGS="-mod=mod"
+
+go get -u -d golang.org/x/lint/golint
 go install golang.org/x/lint/golint
+
 golint ${LINT_EXIT_STATUS} ./...
 popd

--- a/test-runner/gotest.sh
+++ b/test-runner/gotest.sh
@@ -10,5 +10,5 @@ if [ -n "$1" ]; then
 fi
 
 pushd ${MODULE_DIR}
-go test -v ./...
+go test -mod=mod -v ./...
 popd

--- a/test-runner/govet.sh
+++ b/test-runner/govet.sh
@@ -10,5 +10,5 @@ if [ -n "$1" ]; then
 fi
 
 pushd ${MODULE_DIR}
-go vet ./...
+go vet -mod=mod ./...
 popd


### PR DESCRIPTION
Some changes that should fix stable branch tests on OSPdO
but should still work with latest.