### PR TITLE
Install go lint in separate go.mod

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.0 # don't bump this until all operators use 1.18
+          go-version: 1.18.0
       - name: Checkout project code
         uses: actions/checkout@v2
         with:

--- a/test-runner/golint.sh
+++ b/test-runner/golint.sh
@@ -13,12 +13,15 @@ if [ -n "$1" ]; then
     MODULE_DIR=$1
 fi
 
-pushd ${MODULE_DIR}
-
-export GOFLAGS="-mod=mod"
-
-go get -u -d golang.org/x/lint/golint
+mkdir lint
+pushd lint
+go mod init example.com/lint
+go get -d golang.org/x/lint/golint
 go install golang.org/x/lint/golint
+popd
+
+pushd ${MODULE_DIR}
+export GOFLAGS="-mod=mod"
 
 golint ${LINT_EXIT_STATUS} ./...
 popd


### PR DESCRIPTION
This avoids issues issues with deps getting updated when we run 'go get' in the projects go module. Should keep us from seeing test failures where unexpected dependencies creep in.