### PR TITLE
Use Hash instead of Branch name to replace go.mod

### DIFF
--- a/.github/workflows/reusable-workflow-e2e.yaml
+++ b/.github/workflows/reusable-workflow-e2e.yaml
@@ -183,10 +183,10 @@ jobs:
       run: |
         pushd ${{ github.workspace }}
         version=`cat go.mod | grep -m 1 github.com/openstack-k8s-operators/keystone-operator/api | cut -d ' ' -f2`
-        go mod edit --replace github.com/openstack-k8s-operators/${{ inputs.operator_name }}/api@$version=github.com/${{github.event.pull_request.head.repo.full_name}}/api@${{ github.head_ref }}
+        go mod edit --replace github.com/openstack-k8s-operators/${{ inputs.operator_name }}/api@$version=github.com/${{github.event.pull_request.head.repo.full_name}}/api@${{github.event.pull_request.head.sha}}
         go mod tidy
         cd ./apis/
-        go mod edit --replace github.com/openstack-k8s-operators/${{ inputs.operator_name }}/api@$version=github.com/${{github.event.pull_request.head.repo.full_name}}/api@${{ github.head_ref }}
+        go mod edit --replace github.com/openstack-k8s-operators/${{ inputs.operator_name }}/api@$version=github.com/${{github.event.pull_request.head.repo.full_name}}/api@${{github.event.pull_request.head.sha}}
         go mod tidy
         git diff
         popd


### PR DESCRIPTION
Ci for PR coming from Depenandabot is failing with the below because of slashes in the branch name which Dependabot creates.

https://github.com/openstack-k8s-operators/keystone-operator/actions/runs/3444156331/jobs/5746524087#step:4:19

Before this patch, we replaced go.mod in openstack-operator with PR commit using the branch name.

ex:
~~~
go mod edit --replace
github.com/openstack-k8s-operators/keystone-operator/api@$version= github.com/ysandeep93/keystone-operator/api@dependabot/go_modules/ sigs.k8s.io/controller-runtime-0.13.1
~~~

After Go 1.13, there is a known issue if we have slashes in the branch name.[1]

~~~
$go mod tidy
go: errors parsing go.mod:
/tmp/openstack-operator/go.mod:97:
replace github.com/ysandeep93/keystone-operator/api: version "dependabot/go_modules/sigs.k8s.io/controller-runtime-0.13.1" invalid: version "dependabot/go_modules/sigs.k8s.io/controller-runtime-0.13.1" invalid: disallowed version string
~~~

With this patch, updating our logic to use the hash of the branch instead of the branch name, the same workaround/fix is mentioned here[2].

[1] https://github.com/golang/go/issues/32955
[2] https://github.com/golang/go/issues/34175#issuecomment-529502530