### PR TITLE
Add GOWORK variable to the CI scripts

### DIFF
--- a/test-runner/gofmt.sh
+++ b/test-runner/gofmt.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 
+GOWORK=${GOWORK:-'off'}
 BASE_DIR="$(dirname $0)"
 cd "${BASE_DIR}/../.."
 
@@ -10,5 +11,5 @@ if [ -n "$1" ]; then
 fi
 
 pushd ${MODULE_DIR}
-go fmt ./...
+GOWORK=$GOWORK go fmt ./...
 popd

--- a/test-runner/golangci.sh
+++ b/test-runner/golangci.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 
+GOWORK=${GOWORK:-'off'}
 BASE_DIR="$(dirname $0)"
 cd "${BASE_DIR}/../.."
 
@@ -21,5 +22,5 @@ fi
 
 pushd ${MODULE_DIR}
 
-GOGC=10 GOLANGCI_LINT_CACHE=/tmp/golangci-cache ${BASE_DIR}/../../bin/golangci-lint run --timeout=${TIMEOUT}m -v
+GOWORK=$GOWORK GOGC=10 GOLANGCI_LINT_CACHE=/tmp/golangci-cache ${BASE_DIR}/../../bin/golangci-lint run --timeout=${TIMEOUT}m -v
 popd

--- a/test-runner/golint.sh
+++ b/test-runner/golint.sh
@@ -5,6 +5,7 @@ set -ex
 # "-set_exit_status" otherwise
 LINT_EXIT_STATUS="-set_exit_status"
 
+GOWORK=${GOWORK:-'off'}
 BASE_DIR="$(dirname $0)"
 cd "${BASE_DIR}/../.."
 
@@ -25,5 +26,5 @@ fi
 pushd ${MODULE_DIR}
 export GOFLAGS="-mod=mod"
 
-golint ${LINT_EXIT_STATUS} ./...
+GOWORK=$GOWORK golint ${LINT_EXIT_STATUS} ./...
 popd

--- a/test-runner/gotest.sh
+++ b/test-runner/gotest.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 
+GOWORK=${GOWORK:-'off'}
 BASE_DIR="$(dirname $0)"
 cd "${BASE_DIR}/../.."
 
@@ -10,5 +11,5 @@ if [ -n "$1" ]; then
 fi
 
 pushd ${MODULE_DIR}
-go test -mod=mod -v ./...
+GOWORK=$GOWORK go test -mod=mod -v ./...
 popd

--- a/test-runner/govet.sh
+++ b/test-runner/govet.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 
+GOWORK=${GOWORK:-'off'}
 BASE_DIR="$(dirname $0)"
 cd "${BASE_DIR}/../.."
 
@@ -10,5 +11,5 @@ if [ -n "$1" ]; then
 fi
 
 pushd ${MODULE_DIR}
-go vet -mod=mod ./...
+GOWORK=$GOWORK go vet -mod=mod ./...
 popd


### PR DESCRIPTION
The cinder-operator patch [1] introduces the `go.work` file within the repository with the goal of automating the way we deal with multi module dependencies.
However, the side effect of having a versioned `go.work` in the repo is the failure of the `govet` CI script because `GOWORK` is automatically set to `on`. This patch fixes the CI run on the cinder-operator PR [1], introducing a `GOWORK` variable (which is set to off by default) to make sure we can successfully run this check regardless of the approach.
The `GOWORK` variable value is also inherited from the `Makefile` of the project.

[1] https://github.com/openstack-k8s-operators/cinder-operator/pull/79

Signed-off-by: Francesco Pantano <fpantano@redhat.com>