### PR TITLE
Add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,15 @@
+approvers:
+  - abays
+  - dprince
+  - olliewalsh
+  - Sandeepyadav93
+  - stuggi
+  - viroel
+
+reviewers:
+  - abays
+  - dprince
+  - olliewalsh
+  - Sandeepyadav93
+  - stuggi
+  - viroel


### PR DESCRIPTION
Add OWNERS file, needed when onboarding a new operator for OpenShift-CI.