### PR TITLE
Checkout ci repo from openstack-k8s-operators org

### DIFF
--- a/.github/workflows/reusable-workflow-e2e.yaml
+++ b/.github/workflows/reusable-workflow-e2e.yaml
@@ -313,8 +313,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          repository: tripleo-ci/openstack-k8s-operators-ci
-          ref: check_jobs
+          repository: openstack-k8s-operators/openstack-k8s-operators-ci
 
       - name: Install OpenStack Client
         run: |


### PR DESCRIPTION
We tested reusable workflow in tripleo-ci org first, we missed to update this reference in the initial patch.