### PR TITLE
Add ENVTEST and KUBEBUILDER_ASSETS to gotest

### DIFF
--- a/test-runner/gotest.sh
+++ b/test-runner/gotest.sh
@@ -4,6 +4,10 @@ set -ex
 GOWORK=${GOWORK:-'off'}
 BASE_DIR="$(dirname $0)"
 cd "${BASE_DIR}/../.."
+mkdir -p ${PWD}/bin
+ENVTEST="${PWD}/bin/setup-envtest"
+ENVTEST_K8S_VERSION=$(grep "^ENVTEST_K8S_VERSION" Makefile | awk -F'?= ' '{ print $2 }')
+test -s ${ENVTEST} || GOBIN=${PWD}/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 MODULE_DIR="."
 if [ -n "$1" ]; then
@@ -11,5 +15,5 @@ if [ -n "$1" ]; then
 fi
 
 pushd ${MODULE_DIR}
-GOWORK=$GOWORK go test -mod=mod -v ./...
+KUBEBUILDER_ASSETS="$(${ENVTEST} use ${ENVTEST_K8S_VERSION} -p path)" GOWORK=$GOWORK go test -mod=mod -v ./...
 popd


### PR DESCRIPTION
https://book.kubebuilder.io/reference/envtest.html 
It will allow to uncomment `controllers/suite_test.go` from the operators
