### PR TITLE
Upgrade to golang/sdk1.26

### DIFF
--- a/.github/workflows/reusable-workflow-e2e.yaml
+++ b/.github/workflows/reusable-workflow-e2e.yaml
@@ -177,7 +177,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Edit go.mod file
       run: |
@@ -218,7 +218,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
 
     - name: Checkout openstack-operator repository
       uses: actions/checkout@v2
@@ -233,7 +233,7 @@ jobs:
       uses: redhat-actions/openshift-tools-installer@v1
       with:
         source: github
-        operator-sdk: '1.23.0'
+        operator-sdk: '1.26.0'
 
     - name: Create bundle image
       run: |


### PR DESCRIPTION
Openstack-operator was upgraded to golang 1.19/SDK 1.26 in [1].

Since currently we use the reusable workflow only in keystone-operator. In this patch, I am updating the go-version / operator sdk for steps in which we build openstack operator, will bump in individual operator step when we bump keystone-operator to 1.19

[1]  https://github.com/openstack-k8s-operators/openstack-operator/pull/149