### PR TITLE
Add build root custom Dockerfile

### DIFF
--- a/images/build-root/Dockerfile.custom
+++ b/images/build-root/Dockerfile.custom
@@ -1,0 +1,11 @@
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.18-openshift-4.12
+ARG SDK_VERSION=v1.23.0
+ARG KUSTOMIZE_VERSION=v4.5.7
+USER root
+RUN yum install -y gcc git jq make python39 python39-pip && yum clean all && rm -rf /var/cache/dnf/*
+RUN alternatives --set python3 /usr/bin/python3.9
+RUN curl -s -L "https://github.com/operator-framework/operator-sdk/releases/download/${SDK_VERSION}/operator-sdk_linux_amd64" -o operator-sdk
+RUN chmod +x ./operator-sdk
+RUN mv ./operator-sdk /usr/local/bin
+RUN curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | tar xvzf - -C /usr/local/bin kustomize
+RUN chmod +x /usr/local/bin/kustomize


### PR DESCRIPTION
This patch adds a new custom Dockerfile that can be used to generate different tag, for different versions of golang, operator-sdk and kustomize.