### PR TITLE
Add validation to bins downloaded in root image

### DIFF
--- a/images/build-root/Dockerfile.custom
+++ b/images/build-root/Dockerfile.custom
@@ -7,5 +7,7 @@ RUN alternatives --set python3 /usr/bin/python3.9
 RUN curl -s -L "https://github.com/operator-framework/operator-sdk/releases/download/${SDK_VERSION}/operator-sdk_linux_amd64" -o operator-sdk
 RUN chmod +x ./operator-sdk
 RUN mv ./operator-sdk /usr/local/bin
+RUN /usr/local/bin/operator-sdk version
 RUN curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | tar xvzf - -C /usr/local/bin kustomize
 RUN chmod +x /usr/local/bin/kustomize
+RUN /usr/local/bin/kustomize version


### PR DESCRIPTION
This patch adds a validation on binaries that are download during root image build.