### PR TITLE
[renovate]Allow running make tidy

### DIFF
--- a/renovate.sh
+++ b/renovate.sh
@@ -9,7 +9,7 @@ do
  --token="${RENOVATE_TOKEN}" \
  --git-author="OpenStack K8s CI <openstack-k8s@redhat.com>" \
  --log-file-level=debug \
- --allowed-post-upgrade-commands="^make manifests generate,^make gowork,^make gotidy,^go mod tidy" \
+ --allowed-post-upgrade-commands="^make manifests generate,^make gowork,^go mod tidy,^make tidy" \
  openstack-k8s-operators/openstack-operator \
  openstack-k8s-operators/lib-common \
  openstack-k8s-operators/nova-operator \


### PR DESCRIPTION
The service operator repos all have `make tidy` targets now to run go mod tidy on both mod files in the repo. So to be able to use that in renovate this patch adds that command to the allow list.