### PR TITLE
Run renovate for more operators

### DIFF
--- a/renovate.sh
+++ b/renovate.sh
@@ -19,6 +19,9 @@ do
  openstack-k8s-operators/glance-operator \
  openstack-k8s-operators/placement-operator \
  openstack-k8s-operators/manila-operator \
+ openstack-k8s-operators/heat-operator \
+ openstack-k8s-operators/horizon-operator \
+ openstack-k8s-operators/ironic-operator \
  openstack-k8s-operators/dataplane-operator \
  openstack-k8s-operators/openstack-ansibleee-operator
  echo "sleeping 60 minutes..."


### PR DESCRIPTION
This adds the following three operators to replace dependabot by renovate jobs.
 - heat-operator
 - horizon-operator
 - ironic-operator