### PR TITLE
Remove ovs-operator from renovate script

### DIFF
--- a/renovate.sh
+++ b/renovate.sh
@@ -26,7 +26,6 @@ do
  openstack-k8s-operators/octavia-operator \
  openstack-k8s-operators/neutron-operator \
  openstack-k8s-operators/ovn-operator \
- openstack-k8s-operators/ovs-operator \
  openstack-k8s-operators/heat-operator
 
  echo "sleeping 60 minutes..."


### PR DESCRIPTION
The operator CRD (OVS) was moved to ovn-operator (under OVNController name) and ovs-operator is no longer needed. We plan to archive the repo. This is in preparation to this action.