### PR TITLE
[renovate]Clean up old container images

### DIFF
--- a/renovate.sh
+++ b/renovate.sh
@@ -3,6 +3,9 @@
 set -v
 while true
 do
+ echo "Pruning old images"
+ podman image prune --force
+
  echo "Running Renovate..."
  podman run --rm --pull=always \
  renovate/renovate \


### PR DESCRIPTION
As we always pulling the latest renovate image we need to make sure that old images are cleaned otherwise we will run out of disk space regularly.