### PR TITLE
Limit auto rebase of renovate PRs

### DIFF
--- a/renovate.sh
+++ b/renovate.sh
@@ -6,12 +6,18 @@ do
  echo "Pruning old images"
  podman image prune --force
 
+ # NOTE(gibi): The --update-not-scheduled casues that renovate
+ # will only auto rebase its PRs during our pre-defined schedule
+ # so it won't do rebase at every renovater run if the base
+ # branch changes
+
  echo "Running Renovate..."
  podman run --rm --pull=always \
  renovate/renovate \
  --token="${RENOVATE_TOKEN}" \
  --git-author="OpenStack K8s CI <openstack-k8s@redhat.com>" \
  --log-file-level=debug \
+ --update-not-scheduled=false \
  --allowed-post-upgrade-commands="^make manifests generate,^make gowork,^go mod tidy,^make tidy" \
  openstack-k8s-operators/openstack-operator \
  openstack-k8s-operators/lib-common \


### PR DESCRIPTION
Until now renovate rebased its open PRs every hour if there was a new version from the dependency being bump or if there was a new change on the base branch of the PR. This is fairly wasteful for CI resources.

This change instructs renovate to only auto rebase the PRs during our weekend schedule when new PRs are also considered.

The user can still request rebasing a PR via the checkbox in the PR description.