### PR TITLE
Add skopeo to Dockerfile.custom

### DIFF
--- a/images/build-root/Dockerfile.custom
+++ b/images/build-root/Dockerfile.custom
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.18-open
 ARG SDK_VERSION=v1.23.0
 ARG KUSTOMIZE_VERSION=v4.5.7
 USER root
-RUN yum install -y gcc git jq make python39 python39-pip && yum clean all && rm -rf /var/cache/dnf/*
+RUN yum install -y gcc git jq make python39 python39-pip skopeo && yum clean all && rm -rf /var/cache/dnf/*
 RUN alternatives --set python3 /usr/bin/python3.9
 RUN curl -s -L "https://github.com/operator-framework/operator-sdk/releases/download/${SDK_VERSION}/operator-sdk_linux_amd64" -o operator-sdk
 RUN chmod +x ./operator-sdk


### PR DESCRIPTION
This is needed by the openstack-operator bundle builds which will soon require skopeo in order to execute 'make bundle'