### PR TITLE
Force go version during index build too

### DIFF
--- a/.github/workflows/reusable-build-operator.yaml
+++ b/.github/workflows/reusable-build-operator.yaml
@@ -198,6 +198,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ inputs.go_version }}
+
     - name: Checkout ${{ inputs.operator_name }}-operator repository
       uses: actions/checkout@v4
 

--- a/images/tempest-container/Dockerfile
+++ b/images/tempest-container/Dockerfile
@@ -12,10 +12,6 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf/*
 
-RUN git clone https://git.openstack.org/openstack/openstack-tempest-skiplist && \
-    pushd openstack-tempest-skiplist && \
-    python3 -m pip install . && \
-    popd
 RUN curl -s -L "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o yq
 RUN chmod +x ./yq
 RUN mv ./yq /usr/local/bin


### PR DESCRIPTION
golang 1.21 is pushed by default in latest ubuntu runner image[1] and with that openstack-operator index build fails, we need to force compatible golang version during index image builds too like it's done with bundle image builds.

[1] https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240225.1