### PR TITLE
Manually install tempest-skiplist in tempest container

### DIFF
--- a/images/tempest-container/Dockerfile
+++ b/images/tempest-container/Dockerfile
@@ -12,6 +12,13 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf/*
 
+# Latest commit from skiplist repo before get retired.
+RUN git clone https://opendev.org/openstack/openstack-tempest-skiplist.git && \
+    pushd openstack-tempest-skiplist && \
+    git checkout ec349ebef6942b2343be4584f734559f33eae241 && \
+    pip install . && \
+    popd
+
 RUN curl -s -L "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o yq
 RUN chmod +x ./yq
 RUN mv ./yq /usr/local/bin


### PR DESCRIPTION
Now that openstack-tempest-skiplist is retired, it is now available to install with openstack dependencies. This patch adds a manual installation based on the latest commit in this repo.