### PR TITLE
[pre-commit]Add shared kuttl pre-commit rules

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+    - id: kuttl-single-test-assert
+      name: kuttl-single-test-assert
+      language: script
+      pass_filenames: false
+      entry: pre-commit-hooks/kuttl-single-test-assert.sh
+

--- a/pre-commit-hooks/kuttl-single-test-assert.sh
+++ b/pre-commit-hooks/kuttl-single-test-assert.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Ensure that there are no assert files with more than one TestAssert
+# as the extra TestAsserts are silently ignored by kuttl
+KUTTL_DIR=${1:-"./test/kuttl"}
+! egrep -c --include='*.y*ml' -R -e 'kind: TestAssert' "$KUTTL_DIR" \
+        | grep -v ':0' | grep -v ':1'
+ret=$?
+if [ $ret -ne 0 ]; then
+    echo Kuttl only executes the last TestAssert in an assert file.
+    echo Combine the TestAsserts into a single one with a list of commands.
+fi
+exit $ret


### PR DESCRIPTION
This pre-commit check ensures that no TestAsserts are defined in our kuttl tests that are ignored by kuttl.

This can be then used in the service operators by adding the following to the .pre-commit-config.yaml

```
- repo: https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci
  hooks:
    - id: kuttl-single-test-assert
```