### PR TITLE
[renovate]remove dataplane operator

### DIFF
--- a/renovate.sh
+++ b/renovate.sh
@@ -30,7 +30,6 @@ do
  openstack-k8s-operators/placement-operator \
  openstack-k8s-operators/manila-operator \
  openstack-k8s-operators/ironic-operator \
- openstack-k8s-operators/dataplane-operator \
  openstack-k8s-operators/openstack-ansibleee-operator \
  openstack-k8s-operators/openstack-baremetal-operator \
  openstack-k8s-operators/horizon-operator \


### PR DESCRIPTION
That operator is now merged to openstack-operator

Related: [OSPRH-7421](https://issues.redhat.com//browse/OSPRH-7421)