### PR TITLE
Drop unknown option '--log-file-level=debug'

### DIFF
--- a/renovate.sh
+++ b/renovate.sh
@@ -16,7 +16,6 @@ do
  renovate/renovate \
  --token="${RENOVATE_TOKEN}" \
  --git-author="OpenStack K8s CI <openstack-k8s@redhat.com>" \
- --log-file-level=debug \
  --update-not-scheduled=false \
  --allowed-post-upgrade-commands="^make manifests generate,^make gowork,^go mod tidy,^make tidy" \
  openstack-k8s-operators/openstack-operator \


### PR DESCRIPTION
Renovate script fails with:
```
Storing signatures
DEBUG: Using RE2 regex engine
DEBUG: Parsing configs
DEBUG: Checking for config file in config.js
DEBUG: No config file found on disk - skipping
error: unknown option '--log-file-level=debug'
```

This drops the parameter, the output still shows DEBUG messages.