### PR TITLE
Allow git reset as post task

### DIFF
--- a/renovate.sh
+++ b/renovate.sh
@@ -17,7 +17,7 @@ do
  --token="${RENOVATE_TOKEN}" \
  --git-author="OpenStack K8s CI <openstack-k8s@redhat.com>" \
  --update-not-scheduled=false \
- --allowed-post-upgrade-commands="^make manifests generate,^make gowork,^go mod tidy,^make tidy,^make force-bump" \
+ --allowed-post-upgrade-commands="^make manifests generate,^make gowork,^go mod tidy,^make tidy,^make force-bump,^git reset" \
  openstack-k8s-operators/openstack-operator \
  openstack-k8s-operators/lib-common \
  openstack-k8s-operators/infra-operator \


### PR DESCRIPTION
It turned out that make force-dump alone is not enough. We need to git reset away what renovate did first to avoid leaking through transitive dependency bumps like k8s.io.

Related: [OSPRH-8355](https://issues.redhat.com//browse/OSPRH-8355)