### PR TITLE
Disable setup-go module caching

### DIFF
--- a/.github/workflows/reusable-build-operator.yaml
+++ b/.github/workflows/reusable-build-operator.yaml
@@ -125,6 +125,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ inputs.go_version }}
+        cache: false
 
     - name: Checkout ${{ inputs.operator_name }}-operator repository
       uses: actions/checkout@v4
@@ -216,6 +217,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ inputs.go_version }}
+        cache: false
 
     - name: Checkout ${{ inputs.operator_name }}-operator repository
       uses: actions/checkout@v4


### PR DESCRIPTION
Lack of a go.sum generates a warning.
This go is not used to build the operator, so caching here will not speed up the build.