### PR TITLE
Allow passing a release tag for golangci

### DIFF
--- a/test-runner/golangci.sh
+++ b/test-runner/golangci.sh
@@ -8,7 +8,7 @@ cd "${BASE_DIR}/../.."
 export GOFLAGS="-mod=mod"
 
 # Install golangci
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -x -s --
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -x -s -- $GOLANGCI_TAG
 
 MODULE_DIR="."
 if [ -n "$1" ]; then


### PR DESCRIPTION
v2.0.0 was just release, which makes golangci to fail with the golang version used. This allows passing a release tag for the golangci version should be used.