### PR TITLE
Add force-bump-pull-request workflow

### DIFF
--- a/.github/workflows/force-bump-branches.yaml
+++ b/.github/workflows/force-bump-branches.yaml
@@ -1,0 +1,20 @@
+name: Force bump branches
+
+on:
+  workflow_call:
+    inputs:
+      operator_name:
+        required: true
+        type: string
+
+jobs:
+
+  trigger-jobs:
+    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/force-bump-pull-request.yaml@main
+    strategy:
+      matrix:
+        # maintain this list here so we can manage it in one location for all repos
+        branch: ["main", "18.0-fr2"]
+    with:
+      operator_name: ${{ inputs.operator_name }}
+      branch_name: ${{ matrix.branch }}

--- a/.github/workflows/force-bump-pull-request.yaml
+++ b/.github/workflows/force-bump-pull-request.yaml
@@ -1,0 +1,58 @@
+name: Generate a PR to bump openstack-k8s-operators dependencies
+
+on:
+  workflow_call:
+    inputs:
+      operator_name:
+        required: true
+        type: string
+      branch_name:
+        default: 'main'
+        type: string
+
+jobs:
+
+  force-bump-pr:
+    name: Generate a pull request update to the latest openstack-k8s-operators dependencies for the selected operator
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch_name }}
+
+    - name: Git config
+      run: |
+        git config user.name "openstack-k8s-operators-ci"
+        git config user.email "openstack-k8s-operators-ci@github.com"
+
+    - name: run make force-bump, tidy, manifests, generate
+      shell: bash
+      run: |
+        make force-bump
+        make tidy
+        make manifests generate
+
+    - name: run make bindata
+      if: inputs.operator_name == 'openstack'
+      shell: bash
+      run: |
+        BRANCH='${{ inputs.branch_name }}' make bindata
+
+    - name: Detect if there are local git changes and set a variable
+      id: git_diff
+      run: |
+        if git diff --quiet; then
+            echo "changes=false" >> $GITHUB_OUTPUT
+        else
+            echo "changes=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Create Pull Request
+      if: steps.git_diff.outputs.changes == 'true'
+      uses: peter-evans/create-pull-request@v7
+      with:
+        title: "openstack-k8s-operators dependency bump branch: ${{ inputs.branch_name }}"
+        branch: "openstack-dependency-bump/${{ inputs.branch_name }}"
+        commit-message: "Update openstack-k8s-operators (${{ inputs.branch_name }})"


### PR DESCRIPTION
This workflow calls force-bump and generates a pull request which should contain all the necissary updates to manifests. For openstack-operator bindata is also updated.

If no changes are detected no PR should get generated

Includes an additional force-bump-branches workflow which can be called via a schedule job in the operator repos to schedule PRs for all stable braches (main, fr2, etc) to be automatically generated on weekends.

Jira: [OSPRH-15737](https://issues.redhat.com//browse/OSPRH-15737)