### PR TITLE
BRANCH should be supplied to force-bump, not bindata

### DIFF
--- a/.github/workflows/force-bump-pull-request.yaml
+++ b/.github/workflows/force-bump-pull-request.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: run make force-bump, tidy, manifests, generate
       shell: bash
       run: |
-        make force-bump
+        BRANCH='${{ inputs.branch_name }}' make force-bump
         make tidy
         make manifests generate
 
@@ -41,7 +41,7 @@ jobs:
       if: inputs.operator_name == 'openstack'
       shell: bash
       run: |
-        BRANCH='${{ inputs.branch_name }}' make bindata
+        make bindata
 
     - name: Detect if there are local git changes and set a variable
       id: git_diff


### PR DESCRIPTION
It is already getting set locally on most release
branches so we didn't catch this. The intent
in setting BRANCH here is so we might
consider not having to update the Makefiles
in release branches with regards to this default