### PR TITLE
Pass GITHUB_TOKEN to make steps to prevent rate limiting

### DIFF
--- a/.github/workflows/force-bump-pull-request.yaml
+++ b/.github/workflows/force-bump-pull-request.yaml
@@ -32,6 +32,8 @@ jobs:
 
     - name: run make force-bump, tidy, manifests, generate
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         BRANCH='${{ inputs.branch_name }}' make force-bump
         make tidy
@@ -40,6 +42,8 @@ jobs:
     - name: run make bindata
       if: inputs.operator_name == 'openstack'
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         make bindata
 


### PR DESCRIPTION
Adds GITHUB_TOKEN environment variable to the force-bump and bindata steps to enable authenticated GitHub downloads. This prevents rate limiting errors when make targets download tools like kustomize, yq, operator-sdk, etc. from GitHub.

Fixes: "Github rate-limiter failed the request. Either authenticate or wait a couple of minutes" errors in CI builds.

- Added GITHUB_TOKEN env to "make force-bump, tidy, manifests, generate" step
- Added GITHUB_TOKEN env to "make bindata" step (openstack operator only)

Jira: [OSPRH-17779](https://issues.redhat.com//browse/OSPRH-17779)