### PR TITLE
Add helper script to update the fr branch on prow jobs

### DIFF
--- a/switch_prow_jobs_fr_branch.sh
+++ b/switch_prow_jobs_fr_branch.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Check if both parameters are provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <CURRENT> <NEXT>"
+    echo "Example: $0 fr3 fr4"
+    exit 1
+fi
+
+set -ex
+
+CURRENT=$1
+NEXT=$2
+
+for X in $(find . | grep 18.0-fr); do
+    #rename the file (NOTE: prow jobs require frX in the name)
+    NEW_FILE=$(echo $X | sed -e "s|$CURRENT|$NEXT|")
+    git mv $X $NEW_FILE
+
+    #switch the branch
+    sed -i $NEW_FILE -e "s|$CURRENT|$NEXT|"
+done
+export CONTAINER_ENGINE=podman
+make jobs
+make ci-operator-config


### PR DESCRIPTION
Adds switch_prow_jobs_fr_branch.sh to change the current FR branch to the next. CURRENT and NEXT branch can be passes as arguments

Usage: ./switch_prow_jobs_fr_branch.sh <CURRENT> <NEXT>
Example: ./switch_prow_jobs_fr_branch.sh fr3 fr4

Jira: [OSPRH-18078](https://issues.redhat.com//browse/OSPRH-18078)