### PR TITLE
Add label-pr workflow

### DIFF
--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -1,0 +1,24 @@
+name: Add Label to PR
+
+on:
+  workflow_call:
+    inputs:
+      label_name:
+        required: true
+        type: string
+
+jobs:
+  label-pr:
+    name: Label PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add ${{ inputs.label_name }} label on the PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['${{ inputs.label_name }}']
+            });


### PR DESCRIPTION
This can be called from operator repos to help identify repositories with for example API changes using:

on:
  pull_request:
    types: [opened, synchronize, reopened]
    paths:
      - 'config/crd/bases/**'

jobs:
  call-build-workflow:
    permissions: pull-requests: write issues: write with: label_name: crd-changes uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/label-pr.yaml@main