### PR TITLE
Fix nginx /id endpoint on Fedora 43

### DIFF
--- a/artifacts/tobiko-images/conf/nginx_id.conf
+++ b/artifacts/tobiko-images/conf/nginx_id.conf
@@ -1,5 +1,5 @@
 server{
-    listen 80;
-    listen [::]:80;
+    listen 80 default_server;
+    listen [::]:80 default_server;
     location /id { add_header Content-Type text/plain; return 200 '$hostname';}
 }


### PR DESCRIPTION
Fedora 43's nginx.conf introduces an inline default server block on port 80 before the conf.d include, causing our server block to lose priority and return 404. Adding default_server to the listen directives ensures our server handles port 80 traffic regardless of definition order. This is harmless on Fedora 42 where no competing server exists.

Assisted-by: Claude Opus 4.6