### PR TITLE
Fix CI build root base image to provide Go 1.24

### DIFF
--- a/images/build-root/Dockerfile.rhel-9.custom
+++ b/images/build-root/Dockerfile.rhel-9.custom
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.21
 ARG SDK_VERSION=v1.31.0
 ARG KUSTOMIZE_VERSION=v5.0.3
 ARG YQ_VERSION=v4.44.5


### PR DESCRIPTION
The rhel-9-release-golang-1.20-openshift-4.14 base image is a floating tag that was recently rebuilt with Go 1.23, breaking all operators that declare go 1.24.x in go.mod with:

  invalid go version '1.24.4': must match format 1.23

Update the base image to rhel-9-release-golang-1.24-openshift-4.21 which explicitly provides Go 1.24.