### PR TITLE
Fix opm render failure due to v1-format registries.conf

### DIFF
--- a/.github/workflows/reusable-build-operator.yaml
+++ b/.github/workflows/reusable-build-operator.yaml
@@ -298,6 +298,10 @@ jobs:
         INDEX_IMAGE_TAG: ${{ env.latesttag }}
         INDEX_IMAGE: ${{ inputs.operator_name }}-operator-index
         CSV_VERSION: v${{ steps.get_csv_version.outputs.version }}
+        # opm uses containers/image which now rejects v1-format registries.conf
+        # shipped on ubuntu-latest runners. Safe to bypass since opm render
+        # pulls by fully-qualified reference and needs no registry aliases.
+        CONTAINERS_REGISTRIES_CONF: /dev/null
 
     - name: Push ${{ inputs.operator_name }}-operator-index To ${{ env.imageregistry }}
       uses: redhat-actions/push-to-registry@v2


### PR DESCRIPTION
## Summary
- Recent `containers/image` library versions (used by `opm`) now hard-error on v1-format `registries.conf` instead of silently converting it
- GitHub Actions `ubuntu-latest` runners ship `/etc/containers/registries.conf` in v1 format, breaking the "Create index image" step for all operators
- Fix: set `CONTAINERS_REGISTRIES_CONF=/dev/null` for the `opm` steps — safe because `opm render` pulls by fully-qualified image reference and needs no registry aliases

## Failure example
```
opm render quay.io/.../infra-operator-bundle:abc123 --output yaml
error: loading registries configuration "/etc/containers/registries.conf": registries.conf must be in v2 format but is in v1
```

Example failed run: https://github.com/lmiccini/infra-operator/actions/runs/26489664801/job/78004845915

## Related
- operator-framework/operator-lifecycle-manager#3839 — same root cause, fixed for their `image-canonical-ref` tool
