### PR TITLE
Use the latest installer for golangci-lint

### DIFF
--- a/test-runner/golangci.sh
+++ b/test-runner/golangci.sh
@@ -8,7 +8,7 @@ cd "${BASE_DIR}/../.."
 export GOFLAGS="-mod=mod"
 
 # Install golangci
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -x -s -- $GOLANGCI_TAG
+curl -sSfL https://golangci-lint.run/install.sh | bash -x -s -- $GOLANGCI_TAG
 
 MODULE_DIR="."
 if [ -n "$1" ]; then


### PR DESCRIPTION
Lately, the golangci-lint project started providing sbom.json in the checksum file that they are publishing along with the project tarball. The installer shell script that we download does not take this sbom file into account yet, so it parses the checksum file incorrectly and fails to validate the hash of the downloaded tarball.

As explained in golangci-lint changelog [1], we should now fetch the installer from a new URL to fix the issue.

[1] https://golangci-lint.run/docs/product/changelog/#v2121