### PR TITLE
Switch Renovate to GitHub App authentication

### DIFF
--- a/docs/renovate-github-app-setup.md
+++ b/docs/renovate-github-app-setup.md
@@ -76,7 +76,7 @@ RENOVATE_GITHUB_APP_TOKEN=$(podman run --rm \
 podman run -e RENOVATE_TOKEN="${RENOVATE_GITHUB_APP_TOKEN}" \
   -e BINDATA_GIT_ADD=true -e LOG_LEVEL=debug --rm \
   localhost/renovate:local \
-  --git-author="OpenStack K8s CI <openstack-k8s@redhat.com>" \
+  --git-author="ospk8s-renovate[bot] <296544045+ospk8s-renovate[bot]@users.noreply.github.com>" \
   --update-not-scheduled=false \
   --allowed-post-upgrade-commands="^make manifests generate,^make bindata,^make gowork,^go mod tidy,^make tidy,^make force-bump,^git reset" \
   <repo-list> 2>&1 | tee $log_file

--- a/docs/renovate-github-app-setup.md
+++ b/docs/renovate-github-app-setup.md
@@ -1,0 +1,86 @@
+# Renovate GitHub App Setup
+
+## Why a GitHub App?
+
+The Renovate self-hosted runner needs to push branches that modify
+`.github/workflows/` files (e.g., pinning action SHAs). GitHub requires
+the `workflow` scope for PATs to do this, but GitHub Apps use a separate
+**Workflows: write** permission which is more granular and scoped to
+installed repos only.
+
+## Setup
+
+### 1. Create a GitHub App
+
+Go to **Organization settings → Developer settings → GitHub Apps → New GitHub App**.
+
+Settings:
+- **Name**: e.g., `openstack-k8s-operators-renovate`
+- **Homepage URL**: org URL
+- **Expire user authorization tokens**: Yes (default)
+- **Webhook**: Deactivate (not needed for self-hosted Renovate)
+
+**Repository permissions:**
+- **Commit statuses**: Read & write
+- **Contents**: Read & write
+- **Dependabot alerts**: Read-only
+- **Metadata**: Read-only (auto-selected)
+- **Pull requests**: Read & write
+- **Workflows**: Read & write
+
+No organization or account permissions needed.
+
+### 2. Generate a private key
+
+On the App settings page, scroll to **Private keys** → **Generate a private key**.
+Save the `.pem` file on the runner machine (e.g., `/home/cloud-user/renovate_github_private_key.pem`).
+
+### 3. Install the App
+
+Go to **Organization settings → Third-party Access → GitHub Apps** → install your
+App on the organization. Select the repos Renovate should manage.
+
+### 4. Get the IDs
+
+- **App ID**: On the App settings page, shown at the top
+- **Installation ID**: Go to **Organization settings → Third-party Access → GitHub Apps**
+  → click **Configure** next to the app. The URL looks like:
+  `https://github.com/organizations/YOUR_ORG/settings/installations/12345678`
+  — the number at the end (`12345678`) is the Installation ID.
+
+### 5. Configure the runner
+
+Add to `~/.bash_profile` on the runner machine:
+
+```bash
+export RENOVATE_GITHUB_APP_ID=<your-app-id>
+export RENOVATE_GITHUB_INSTALLATION_ID=<your-installation-id>
+export RENOVATE_GITHUB_APP_KEY=/path/to/renovate_github_private_key.pem
+```
+
+### 6. Update the renovate script
+
+The script generates an installation token from the App credentials, then
+passes it to Renovate:
+
+```bash
+# Fetch installation token from GitHub App
+RENOVATE_GITHUB_APP_TOKEN=$(podman run --rm \
+  -v "${RENOVATE_GITHUB_APP_KEY}:/key.pem:ro,Z" \
+  ghcr.io/mshekow/github-app-installation-token:latest \
+  "${RENOVATE_GITHUB_APP_ID}" \
+  "${RENOVATE_GITHUB_INSTALLATION_ID}" \
+  "/key.pem")
+
+# Run Renovate with the App token
+podman run -e RENOVATE_TOKEN="${RENOVATE_GITHUB_APP_TOKEN}" \
+  -e BINDATA_GIT_ADD=true -e LOG_LEVEL=debug --rm \
+  localhost/renovate:local \
+  --git-author="OpenStack K8s CI <openstack-k8s@redhat.com>" \
+  --update-not-scheduled=false \
+  --allowed-post-upgrade-commands="^make manifests generate,^make bindata,^make gowork,^go mod tidy,^make tidy,^make force-bump,^git reset" \
+  <repo-list> 2>&1 | tee $log_file
+```
+
+The installation token expires after 1 hour. If the Renovate run takes
+longer, regenerate the token before each run iteration.

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,12 @@
   ],
   "baseBranchPatterns": [
     "main"
+  ],
+  "packageRules": [
+    {
+      "description": "Don't bump runs-on runner versions — some workflows pin older runners due to tool compatibility issues (e.g. virt-customize fails on ubuntu-24.04)",
+      "matchDatasources": ["github-runners"],
+      "enabled": false
+    }
   ]
 }

--- a/renovate.sh
+++ b/renovate.sh
@@ -1,5 +1,12 @@
 # This is what we use to run a self-hosted Renovate to create github PR's.
 # Running self-hosted is required to be able to execute the postUpgradeCommands
+#
+# Required environment variables (set in ~/.bash_profile on the runner):
+#   RENOVATE_GITHUB_APP_ID          - GitHub App ID
+#   RENOVATE_GITHUB_INSTALLATION_ID - GitHub App Installation ID
+#   RENOVATE_GITHUB_APP_KEY         - Path to GitHub App private key (.pem)
+#
+# See docs/renovate-github-app-setup.md for setup instructions.
 set -v
 
 while true
@@ -31,10 +38,17 @@ EOF_CAT
 
  log_file="$log_dir/renovate_$(date +'%Y%m%d_%H%M%S').log"
 
+ # Generate a GitHub App installation token (expires after 1 hour)
+ RENOVATE_GITHUB_APP_TOKEN=$(podman run --rm \
+   -v "${RENOVATE_GITHUB_APP_KEY}:/key.pem:ro,Z" \
+   ghcr.io/mshekow/github-app-installation-token:latest \
+   "${RENOVATE_GITHUB_APP_ID}" \
+   "${RENOVATE_GITHUB_INSTALLATION_ID}" \
+   "/key.pem")
+
  echo "Running Renovate..."
- podman run -e BINDATA_GIT_ADD=true -e LOG_LEVEL=debug --rm \
+ podman run -e RENOVATE_TOKEN="${RENOVATE_GITHUB_APP_TOKEN}" -e BINDATA_GIT_ADD=true -e LOG_LEVEL=debug --rm \
  localhost/renovate:local \
- --token="${RENOVATE_TOKEN}" \
  --git-author="OpenStack K8s CI <openstack-k8s@redhat.com>" \
  --update-not-scheduled=false \
  --allowed-post-upgrade-commands="^make manifests generate,^make bindata,^make gowork,^go mod tidy,^make tidy,^make force-bump,^git reset" \
@@ -59,7 +73,8 @@ EOF_CAT
  openstack-k8s-operators/barbican-operator \
  openstack-k8s-operators/swift-operator \
  openstack-k8s-operators/test-operator \
- openstack-k8s-operators/watcher-operator 2>&1 | tee $log_file
+ openstack-k8s-operators/watcher-operator \
+ openstack-k8s-operators/openstack-k8s-operators-ci 2>&1 | tee $log_file
 
  echo "sleeping 60 minutes..."
  sleep 3600

--- a/renovate.sh
+++ b/renovate.sh
@@ -49,7 +49,7 @@ EOF_CAT
  echo "Running Renovate..."
  podman run -e RENOVATE_TOKEN="${RENOVATE_GITHUB_APP_TOKEN}" -e BINDATA_GIT_ADD=true -e LOG_LEVEL=debug --rm \
  localhost/renovate:local \
- --git-author="OpenStack K8s CI <openstack-k8s@redhat.com>" \
+ --git-author="ospk8s-renovate[bot] <296544045+ospk8s-renovate[bot]@users.noreply.github.com>" \
  --update-not-scheduled=false \
  --allowed-post-upgrade-commands="^make manifests generate,^make bindata,^make gowork,^go mod tidy,^make tidy,^make force-bump,^git reset" \
  openstack-k8s-operators/openstack-operator \

--- a/renovate.sh
+++ b/renovate.sh
@@ -44,7 +44,12 @@ EOF_CAT
    ghcr.io/mshekow/github-app-installation-token:latest \
    "${RENOVATE_GITHUB_APP_ID}" \
    "${RENOVATE_GITHUB_INSTALLATION_ID}" \
-   "/key.pem")
+   "/key.pem") || { echo "ERROR: Failed to generate GitHub App token"; continue; }
+
+ if [ -z "${RENOVATE_GITHUB_APP_TOKEN}" ]; then
+   echo "ERROR: GitHub App token is empty"
+   continue
+ fi
 
  echo "Running Renovate..."
  podman run -e RENOVATE_TOKEN="${RENOVATE_GITHUB_APP_TOKEN}" -e BINDATA_GIT_ADD=true -e LOG_LEVEL=debug --rm \


### PR DESCRIPTION
Use a GitHub App instead of a PAT for Renovate authentication. GitHub Apps provide more granular permission control — the Workflows permission can be granted specifically, whereas PATs require the broad workflow scope. This is needed because pinning GitHub Actions to SHA modifies .github/workflows/ files.

- Update renovate.sh to generate installation tokens via ghcr.io/mshekow/github-app-installation-token
- Add docs/renovate-github-app-setup.md with setup instructions
- Add openstack-k8s-operators-ci to the managed repo list

Also Disable GitHub runner version bumps in Renovate
Some workflows pin older runners due to tool compatibility issues (e.g. virt-customize fails on ubuntu-24.04). Disable the github-runners datasource so Renovate does not bump runs-on versions automatically.

Jira: [OSPRH-31856](https://redhat.atlassian.net/browse/OSPRH-31856)