### PR TITLE
Fix branching workflow: handle baseBranches and remove archived repo

### DIFF
--- a/.github/workflows/create-release-branch-v1.yml
+++ b/.github/workflows/create-release-branch-v1.yml
@@ -481,8 +481,12 @@ jobs:
               echo "Stable branch detected. Updating renovate.json to use ${BRANCH_NAME}.json5..."
               # Replace the extends reference to use the branch-specific config
               sed -i "s|renovate-config:default\.json5|renovate-config:${BRANCH_NAME}.json5|g" renovate.json
-              # Replace baseBranchPatterns to target the stable branch (only in baseBranchPatterns array)
-              jq --arg branch "${BRANCH_NAME}" '.baseBranchPatterns = [$branch]' renovate.json > renovate.json.tmp && mv renovate.json.tmp renovate.json
+              # Replace baseBranchPatterns/baseBranches to target the stable branch
+              jq --arg branch "${BRANCH_NAME}" '
+                if has("baseBranchPatterns") then .baseBranchPatterns = [$branch] else . end |
+                if has("baseBranches") then .baseBranches = [$branch] else . end |
+                if (has("baseBranchPatterns") | not) and (has("baseBranches") | not) then .baseBranchPatterns = [$branch] else . end
+              ' renovate.json > renovate.json.tmp && mv renovate.json.tmp renovate.json
 
               if ! git diff --quiet -- renovate.json; then
                 echo "Changes detected in renovate.json"

--- a/feature_branch_repos.yaml
+++ b/feature_branch_repos.yaml
@@ -34,7 +34,6 @@ repos:
   - name: openstack-network-exporter
   - name: openstack-operator
   - name: ovn-operator
-  - name: placement-operator
   - name: prometheus-podman-exporter
     skip_makefile_changes: true
   - name: sg-core


### PR DESCRIPTION
Fix renovate.json update to handle both baseBranchPatterns and baseBranches field names (telemetry-operator uses baseBranches). Remove placement-operator from repo list (archived).

Jira: [OSPRH-32639](https://redhat.atlassian.net/browse/OSPRH-32639)