### PR TITLE
Dependency pr dashboard and workflow to update Renovate baseBranchPatterns across all repos

### DIFF
--- a/.github/workflows/update-renovate-branches.yaml
+++ b/.github/workflows/update-renovate-branches.yaml
@@ -1,0 +1,172 @@
+name: Update Renovate baseBranchPatterns
+
+on:
+  workflow_dispatch:
+    inputs:
+      BRANCHES:
+        description: 'Comma-separated list of branches Renovate should target (e.g. "main,18-stable"). main must always be included.'
+        required: true
+        type: string
+      DRY_RUN:
+        description: 'Show changes without creating PRs'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  update-renovate:
+    runs-on: ubuntu-latest
+    env:
+      ORG_NAME: ${{ github.repository_owner }}
+      REPO_LIST_FILE: 'feature_branch_repos.yaml'
+    steps:
+      - name: Generate a token from the GitHub App
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Validate inputs
+        env:
+          BRANCHES: ${{ inputs.BRANCHES }}
+        run: |
+          set -eo pipefail
+
+          if ! echo "$BRANCHES" | grep -qw "main"; then
+            echo "::error::BRANCHES must include 'main'. Got: $BRANCHES"
+            exit 1
+          fi
+
+          echo "Branches to set: $BRANCHES"
+
+      - name: Update renovate.json in all repos
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCHES: ${{ inputs.BRANCHES }}
+          DRY_RUN: ${{ inputs.DRY_RUN }}
+        run: |
+          set -eo pipefail
+
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
+          # Build the JSON array for baseBranchPatterns
+          BRANCH_JSON=$(echo "$BRANCHES" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | jq -R . | jq -s .)
+          echo "baseBranchPatterns will be set to: $BRANCH_JSON"
+
+          # Read repo list
+          REPOS=$(yq e '.repos[].name' "$REPO_LIST_FILE")
+
+          SUCCEEDED=()
+          SKIPPED=()
+
+          PR_BRANCH="update-renovate-branches"
+
+          for repo in $REPOS; do
+            echo ""
+            echo "========================================="
+            echo "Processing: $repo"
+            echo "========================================="
+
+            # Check if renovate.json exists on main
+            if ! gh api "repos/${ORG_NAME}/${repo}/contents/renovate.json?ref=main" --jq '.content' > /dev/null 2>&1; then
+              echo "  SKIP: no renovate.json on main"
+              SKIPPED+=("$repo: no renovate.json")
+              continue
+            fi
+
+            # Fetch current renovate.json
+            CURRENT=$(gh api "repos/${ORG_NAME}/${repo}/contents/renovate.json?ref=main" --jq '.content' | base64 -d)
+            if [ -z "$CURRENT" ]; then
+              echo "  SKIP: empty renovate.json"
+              SKIPPED+=("$repo: empty renovate.json")
+              continue
+            fi
+
+            # Check if baseBranchPatterns already matches
+            CURRENT_BRANCHES=$(echo "$CURRENT" | jq -c '.baseBranchPatterns // []' 2>/dev/null)
+            if [ "$CURRENT_BRANCHES" = "$(echo "$BRANCH_JSON" | jq -c .)" ]; then
+              echo "  SKIP: baseBranchPatterns already up to date"
+              SKIPPED+=("$repo: already up to date")
+              continue
+            fi
+
+            # Update baseBranchPatterns and ensure useBaseBranchConfig is set
+            # Detect indent from current file (default 2 spaces)
+            INDENT=$(echo "$CURRENT" | grep -m1 '^ ' | sed 's/[^ ].*//' | wc -c)
+            INDENT=$((INDENT - 1))
+            if [ "$INDENT" -lt 1 ]; then INDENT=2; fi
+
+            UPDATED=$(echo "$CURRENT" | jq --argjson branches "$BRANCH_JSON" --indent "$INDENT" '
+              .baseBranchPatterns = $branches |
+              .useBaseBranchConfig = "merge"
+            ')
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "  DRY RUN: would update baseBranchPatterns to $BRANCH_JSON"
+              SUCCEEDED+=("$repo: would update (dry run)")
+              continue
+            fi
+
+            # Check if PR branch already exists
+            if gh api "repos/${ORG_NAME}/${repo}/git/ref/heads/${PR_BRANCH}" > /dev/null 2>&1; then
+              echo "  Deleting existing branch ${PR_BRANCH}"
+              gh api -X DELETE "repos/${ORG_NAME}/${repo}/git/ref/heads/${PR_BRANCH}" > /dev/null 2>&1 || true
+            fi
+
+            # Get main branch SHA
+            MAIN_SHA=$(gh api "repos/${ORG_NAME}/${repo}/git/ref/heads/main" --jq '.object.sha')
+
+            # Create branch
+            gh api "repos/${ORG_NAME}/${repo}/git/refs" \
+              -f "ref=refs/heads/${PR_BRANCH}" \
+              -f "sha=${MAIN_SHA}" > /dev/null
+
+            # Get current file SHA for the update
+            FILE_SHA=$(gh api "repos/${ORG_NAME}/${repo}/contents/renovate.json?ref=main" --jq '.sha')
+
+            # Update the file
+            CONTENT_B64=$(echo "$UPDATED" | base64 -w 0)
+            gh api -X PUT "repos/${ORG_NAME}/${repo}/contents/renovate.json" \
+              -f "message=Update Renovate baseBranchPatterns" \
+              -f "content=${CONTENT_B64}" \
+              -f "sha=${FILE_SHA}" \
+              -f "branch=${PR_BRANCH}" > /dev/null
+
+            # Create PR
+            PR_BODY="Update baseBranchPatterns in renovate.json to target branches: ${BRANCHES}."
+            PR_BODY="${PR_BODY}
+
+            This ensures Renovate creates dependency update PRs for all active branches."
+            PR_URL=$(gh pr create \
+              --repo "${ORG_NAME}/${repo}" \
+              --head "${PR_BRANCH}" \
+              --base main \
+              --title "Update Renovate baseBranchPatterns" \
+              --body "$PR_BODY" 2>&1)
+
+            echo "  OK: $PR_URL"
+            SUCCEEDED+=("$repo: $PR_URL")
+          done
+
+          echo ""
+          echo "========================================="
+          echo "SUMMARY"
+          echo "========================================="
+          echo ""
+          echo "Succeeded (${#SUCCEEDED[@]}):"
+          for s in "${SUCCEEDED[@]}"; do echo "  $s"; done
+          echo ""
+          echo "Skipped (${#SKIPPED[@]}):"
+          for s in "${SKIPPED[@]}"; do echo "  $s"; done

--- a/README.md
+++ b/README.md
@@ -1,21 +1,81 @@
 # openstack-k8s-operators-ci
 
-## Image Build Status
-
-[Post merge image build status](docs/image-build-status.md) for all operators across main, 18-stable, and 18.0-fr6 branches.
-
-## Dependency PR Dashboard
-
-[Dependency PR dashboard](docs/dependency-pr-dashboard.md) with search queries for tracking force-bump and Renovate PRs across all branches.
-
-## Description
 Common scripts and tools for the openstack-k8s-operators CI that can be used inside or outside of any CI platform.
 
-## Test Coverage
-The following tests are currently available to be run:
-- **lint**
-	- Source: `test-runner/golint.sh`
-- **vet**
-	- Source: `test-runner/govet.sh`
-- **unit**
-	- Source: `test-runner/gotest.sh`
+## Dashboards
+
+- [Post merge image build status](docs/image-build-status.md) — build badges for all operators across active branches
+- [Dependency PR dashboard](docs/dependency-pr-dashboard.md) — search queries for tracking force-bump and Renovate PRs
+
+## Workflows
+
+### Branching and releases
+
+| Workflow | Trigger | Description |
+|----------|---------|-------------|
+| [Create Feature Branches in Repos v1](.github/workflows/create-release-branch-v1.yml) | `workflow_dispatch` | Creates release/stable branches across all repos, bumps versions, updates CI configs. See [branching procedures](docs/branching-procedures.md). |
+| [Tag RabbitMQ Index Image](.github/workflows/rabbitmq-cluster-operator-index-feature-tag.yaml) | `workflow_dispatch` | Retags the RabbitMQ cluster operator index image for a feature release branch. |
+
+### Dependency management
+
+| Workflow | Trigger | Description |
+|----------|---------|-------------|
+| [Force bump branches](.github/workflows/force-bump-branches.yaml) | `workflow_call` | Bumps openstack-k8s-operators cross-repo dependencies on all active branches. |
+| [Generate force-bump PR](.github/workflows/force-bump-pull-request.yaml) | `workflow_call` | Creates a PR with bumped dependencies for a single repo/branch. Called by force-bump-branches. |
+| [Update Renovate baseBranchPatterns](.github/workflows/update-renovate-branches.yaml) | `workflow_dispatch` | Updates `baseBranchPatterns` in `renovate.json` on main across all repos. Run after creating a new stable branch. |
+
+### CI pipelines (reusable)
+
+| Workflow | Trigger | Description |
+|----------|---------|-------------|
+| [Operator image builder](.github/workflows/reusable-build-operator.yaml) | `workflow_call` | Builds and pushes operator container images. |
+| [Golang lint, vet and unit test](.github/workflows/golangci-lint.yaml) | `workflow_call` | Go linting, vetting, and unit test pipeline. |
+| [Add Label to PR](.github/workflows/label-pr.yaml) | `workflow_call` | Adds labels to pull requests. |
+
+### Image builds
+
+| Workflow | Trigger | Description |
+|----------|---------|-------------|
+| [Build Customized Tobiko Image](.github/workflows/build-custom-tobiko-image.yml) | `workflow_dispatch` | Builds a customized advanced image for Tobiko testing. |
+| [Build Customized WNTP Image](.github/workflows/build-custom-wntp-image.yml) | `workflow_dispatch` | Builds a customized image for WNTP testing. |
+| [Build NAT64 Appliance Image](.github/workflows/build-nat64-appliance.yml) | `workflow_dispatch` | Builds the NAT64 appliance image. |
+
+### Status and reporting
+
+| Workflow | Trigger | Description |
+|----------|---------|-------------|
+| [Update image build status page](.github/workflows/update-image-build-status.yaml) | `workflow_dispatch` | Regenerates the [image build status](docs/image-build-status.md) page with per-branch build badges for all operators. |
+
+## Scripts
+
+### Tools (`tools/`)
+
+| Script | Description |
+|--------|-------------|
+| `tools/delete-branch.sh` | Deletes a branch from all repos in the org. Records commit SHAs for recovery. Dry-run by default, pass `--execute` to apply. |
+
+### CI and release helpers
+
+| Script | Description |
+|--------|-------------|
+| `switch_prow_jobs_fr_branch.sh` | Creates openshift/release Prow job configs for a new FR branch. Usage: `./switch_prow_jobs_fr_branch.sh <old-fr> <new-fr>` |
+| `renovate.sh` | Runs self-hosted Renovate to create dependency update PRs. Requires GitHub App credentials. See [setup docs](docs/renovate-github-app-setup.md). |
+| `stage_downstream_rebase.sh` | Stages downstream rebase for operator bundles against the Red Hat registry. |
+| `build-tools-image.sh` | Builds the CI build-tools container image (`openstack-k8s-operators-ci-build-tools`). |
+| `dockerfile_to_osbs.sh` | Converts Dockerfiles to OSBS format. |
+
+### Test runners (`test-runner/`)
+
+| Script | Description |
+|--------|-------------|
+| `test-runner/golint.sh` | Go lint checks |
+| `test-runner/golangci.sh` | golangci-lint pipeline |
+| `test-runner/govet.sh` | Go vet checks |
+| `test-runner/gotest.sh` | Go unit tests |
+| `test-runner/gofmt.sh` | Go format checks |
+
+### Pre-commit hooks (`pre-commit-hooks/`)
+
+| Script | Description |
+|--------|-------------|
+| `pre-commit-hooks/kuttl-single-test-assert.sh` | Validates that kuttl tests have a single test assertion per file. |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 [Post merge image build status](docs/image-build-status.md) for all operators across main, 18-stable, and 18.0-fr6 branches.
 
+## Dependency PR Dashboard
+
+[Dependency PR dashboard](docs/dependency-pr-dashboard.md) with search queries for tracking force-bump and Renovate PRs across all branches.
+
 ## Description
 Common scripts and tools for the openstack-k8s-operators CI that can be used inside or outside of any CI platform.
 

--- a/docs/branching-procedures.md
+++ b/docs/branching-procedures.md
@@ -52,6 +52,12 @@ This is done once when development shifts to the next major version.
 **Manual prerequisite:**
 - Create `18-stable.json5` in the `renovate-config` repo before running the workflow. Copy from `default.json5` and adjust dependency bounds for the RHOSO 18 OCP target.
 
+**Post-workflow step:**
+- Run the "Update Renovate baseBranchPatterns" workflow to add the new stable
+  branch to `baseBranchPatterns` in `renovate.json` on `main` across all repos.
+  Example input: `main,18-stable`. This ensures Renovate discovers and creates
+  PRs for the new branch.
+
 See [Checklist](#checklist) and [Post-branching tasks](#post-branching-tasks-fr-branches).
 
 ### Scenario 2: Create feature branch for RHOSO 19 (from main)

--- a/docs/dependency-pr-dashboard.md
+++ b/docs/dependency-pr-dashboard.md
@@ -1,0 +1,48 @@
+# Dependency PR Dashboard
+
+Search queries for tracking automated dependency update PRs across the
+openstack-k8s-operators org.
+
+## Force-bump PRs (openstack-dependency-bump)
+
+The force-bump workflow creates PRs that bump cross-repo openstack-k8s-operators
+dependencies (lib-common, service operator APIs). These are authored by
+`github-actions[bot]` on branches named `openstack-dependency-bump/<branch>`.
+
+### All open
+
+[All open dependency bump PRs](https://github.com/pulls?q=is%3Apr+is%3Aopen+org%3Aopenstack-k8s-operators+author%3Aapp%2Fgithub-actions+head%3Aopenstack-dependency-bump)
+
+### Per branch
+
+| Branch | Query |
+|--------|-------|
+| main | [main](https://github.com/pulls?q=is%3Apr+is%3Aopen+org%3Aopenstack-k8s-operators+author%3Aapp%2Fgithub-actions+head%3Aopenstack-dependency-bump%2Fmain) |
+| 18-stable | [18-stable](https://github.com/pulls?q=is%3Apr+is%3Aopen+org%3Aopenstack-k8s-operators+author%3Aapp%2Fgithub-actions+head%3Aopenstack-dependency-bump%2F18-stable) |
+| 18.0-fr6 | [18.0-fr6](https://github.com/pulls?q=is%3Apr+is%3Aopen+org%3Aopenstack-k8s-operators+author%3Aapp%2Fgithub-actions+head%3Aopenstack-dependency-bump%2F18.0-fr6) |
+
+### Including merged/closed
+
+[All dependency bump PRs (any state)](https://github.com/pulls?q=is%3Apr+org%3Aopenstack-k8s-operators+author%3Aapp%2Fgithub-actions+head%3Aopenstack-dependency-bump)
+
+## Renovate PRs
+
+Renovate creates PRs for Go module updates, GitHub Actions digest pinning, and
+other dependency updates. These are authored by `ospk8s-renovate[bot]` (the
+GitHub App) on branches prefixed with `renovate/`.
+
+### All open
+
+[All open Renovate PRs](https://github.com/pulls?q=is%3Apr+is%3Aopen+org%3Aopenstack-k8s-operators+author%3Aapp%2Fospk8s-renovate)
+
+### Per branch
+
+| Branch | Query |
+|--------|-------|
+| main | [main](https://github.com/pulls?q=is%3Apr+is%3Aopen+org%3Aopenstack-k8s-operators+author%3Aapp%2Fospk8s-renovate+head%3Arenovate%2Fmain) |
+| 18-stable | [18-stable](https://github.com/pulls?q=is%3Apr+is%3Aopen+org%3Aopenstack-k8s-operators+author%3Aapp%2Fospk8s-renovate+head%3Arenovate%2F18-stable) |
+| 18.0-fr6 | [18.0-fr6](https://github.com/pulls?q=is%3Apr+is%3Aopen+org%3Aopenstack-k8s-operators+author%3Aapp%2Fospk8s-renovate+head%3Arenovate%2F18.0-fr6) |
+
+### Including merged/closed
+
+[All Renovate PRs (any state)](https://github.com/pulls?q=is%3Apr+org%3Aopenstack-k8s-operators+author%3Aapp%2Fospk8s-renovate)


### PR DESCRIPTION
* Add dependency PR dashboard with search queries for force-bump and Renovate PRs
* Adds a workflow_dispatch workflow that updates baseBranchPatterns in renovate.json on main across all repos. Takes a comma-separated list of branches (e.g. main,18-stable) and creates PRs in each repo that has a renovate.json.
* updates README.md with documentation on repo content
