### PR TITLE
Fix push-to-registry v3 image tag resolution for digest tags

### DIFF
--- a/.github/workflows/reusable-build-operator.yaml
+++ b/.github/workflows/reusable-build-operator.yaml
@@ -99,9 +99,8 @@ jobs:
       run: |
         DIGEST=$(cat digest.txt | sed -e 's|sha256:||')
         echo "OPERATOR_IMAGE_DIGEST=$DIGEST" >> $GITHUB_ENV
-        podman tag "localhost/${IMAGE}:${GITHUB_SHA}" "${REGISTRY}/${IMAGE}:${DIGEST}"
+        podman tag "localhost/${IMAGE}:${GITHUB_SHA}" "localhost/${IMAGE}:${DIGEST}"
       env:
-        REGISTRY:  ${{ env.imageregistry }}/${{ env.imagenamespace }}
         IMAGE: ${{ inputs.operator_name }}-operator
         GITHUB_SHA: ${{ github.sha }}
 
@@ -190,9 +189,8 @@ jobs:
       run: |
         DIGEST=$(cat digest.txt | sed -e 's|sha256:||')
         echo "OPERATOR_BUNDLE_IMAGE_DIGEST=$DIGEST" >> $GITHUB_ENV
-        podman tag "localhost/${IMAGE}:${GITHUB_SHA}" "${REGISTRY}/${IMAGE}:${DIGEST}"
+        podman tag "localhost/${IMAGE}:${GITHUB_SHA}" "localhost/${IMAGE}:${DIGEST}"
       env:
-        REGISTRY:  ${{ env.imageregistry }}/${{ env.imagenamespace }}
         IMAGE: ${{ inputs.operator_name }}-operator-bundle
         GITHUB_SHA: ${{ github.sha }}
 
@@ -299,8 +297,8 @@ jobs:
         EOF_CAT
         cat catalog/index.yaml
         opm validate catalog
-        podman build -t "${REGISTRY}/${INDEX_IMAGE}:${GITHUB_SHA}" -f catalog.Dockerfile
-        podman tag "${REGISTRY}/${INDEX_IMAGE}:${GITHUB_SHA}" "${REGISTRY}/${INDEX_IMAGE}:${INDEX_IMAGE_TAG}"
+        podman build -t "localhost/${INDEX_IMAGE}:${GITHUB_SHA}" -f catalog.Dockerfile
+        podman tag "localhost/${INDEX_IMAGE}:${GITHUB_SHA}" "localhost/${INDEX_IMAGE}:${INDEX_IMAGE_TAG}"
         popd
       env:
         REGISTRY:  ${{ env.imageregistry }}/${{ env.imagenamespace }}
@@ -330,9 +328,8 @@ jobs:
       run: |
         DIGEST=$(cat digest.txt | sed -e 's|sha256:||')
         echo "OPERATOR_INDEX_IMAGE_DIGEST=$DIGEST" >> $GITHUB_ENV
-        podman tag "${REGISTRY}/${IMAGE}:${GITHUB_SHA}" "${REGISTRY}/${IMAGE}:${DIGEST}"
+        podman tag "localhost/${IMAGE}:${GITHUB_SHA}" "localhost/${IMAGE}:${DIGEST}"
       env:
-        REGISTRY:  ${{ env.imageregistry }}/${{ env.imagenamespace }}
         IMAGE: ${{ inputs.operator_name }}-operator-index
         GITHUB_SHA: ${{ github.sha }}
 


### PR DESCRIPTION
## Summary

- The v2→v3 bump of `redhat-actions/push-to-registry` (commit e304d92) changed how images are resolved: v3 constructs the push source as `localhost/<image>:<tag>`, but `podman tag` was creating tags under the full registry path (`quay.io/ns/<image>:<digest>`), causing `image not known` errors on the digest-tag push step.
- Use `localhost/` namespace for all `podman tag` destinations so `push-to-registry` v3 can find them.
- Also fix the operator-index `podman build` to use short image names for the same reason — `push-to-registry` passes `image: <name>-operator-index` (short name), so the local image must be under `localhost/` not `quay.io/ns/`.

This fixes the post-merge image build/push across all operator repos, e.g.:
https://github.com/openstack-k8s-operators/designate-operator/actions/runs/31263973279/job/93379543881

## Test plan

- [ ] Trigger a build on any operator repo (e.g. designate-operator) and verify all 3 push-with-digest steps pass
- [ ] Verify the operator, bundle, and index images are all pushed with their digest tags to quay.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)